### PR TITLE
Add support for raw HTML retrieval in get_text and get_history functions

### DIFF
--- a/src/wikipedia_histories/get_histories.py
+++ b/src/wikipedia_histories/get_histories.py
@@ -108,12 +108,15 @@ def get_ratings(talk):
     return ratings
 
 
-async def get_text(revid, attempts=0, lang_code="en"):
+async def get_text(revid, attempts=0, lang_code="en", raw_html=False):
     """
-    Pull plain text representation of a revision from API
+    Pull plain text or raw HTML representation of a revision from API.
+
     Parameters:
         revid: revision id of a page
         attempts: The number of attempts at retrieving the id so far
+        lang_code: language code for the wikipedia domain
+        raw_html: If True, return raw HTML content (unparsed) instead of plain text.
     """
     try:
         # async implementation of requests get
@@ -129,15 +132,20 @@ async def get_text(revid, attempts=0, lang_code="en"):
         if attempts == 10:
             return -1
         # If there's a server error, just re-send the request until the server complies
-        return await get_text(revid, attempts=attempts + 1, lang_code=lang_code)
+        return await get_text(revid, attempts=attempts + 1, lang_code=lang_code, raw_html=raw_html)
     # Check if page was deleted (deleted pages have no text and are therefore un-parsable)
     try:
-        raw_html = response["parse"]["text"]["*"]
+        raw_html_content = response["parse"]["text"]["*"]
     # Page error (represents deleted pages)
     except KeyError:
         return None
+
+    # Return raw HTML if the toggle is set
+    if raw_html:
+        return raw_html_content
+
     # Parse raw html from response
-    document = html.document_fromstring(raw_html)
+    document = html.document_fromstring(raw_html_content)
     text = document.xpath("//p")
     paragraphs = []
     for paragraph in text:
@@ -149,7 +157,7 @@ async def get_text(revid, attempts=0, lang_code="en"):
     return cur
 
 
-async def get_texts(revids, lang_code="en"):
+async def get_texts(revids, lang_code="en", raw_html=False):
     """
     Get the text of articles given the list of revision ids
 
@@ -165,18 +173,19 @@ async def get_texts(revids, lang_code="en"):
     sema = 100
     for i in range(0, revids.__len__(), +sema):
         texts += await asyncio.gather(
-            *(get_text(revid, lang_code=lang_code) for revid in revids[i : (i + sema)])
+            *(get_text(revid, lang_code=lang_code, raw_html=raw_html) for revid in revids[i : (i + sema)])
         )
     return texts
 
 
-def get_history(title, include_text=True, domain="en.wikipedia.org"):
+def get_history(title, include_text=True, raw_html=False, domain="en.wikipedia.org"):
     """
     Collects everything and returns a list of Change objects
 
     Parameters:
         title: article title
         include_text: Whether to unclude body text or not. Speed increases if False
+        raw_html: If True, get raw HTML instead of plain text.
     Returns:
         A list of Change objects representing each revision to the
     """
@@ -208,7 +217,7 @@ def get_history(title, include_text=True, domain="en.wikipedia.org"):
     # Get the text of the revisions. Performance is improved if this isn't done, but you lose the revisions
     if include_text:
         lang_code = extract_lang_code_from_domain(domain)
-        texts = asyncio.run(get_texts(revids, lang_code))
+        texts = asyncio.run(get_texts(revids, lang_code, raw_html=raw_html))
     else:
         texts = [""] * len(metadata)
 
@@ -235,8 +244,8 @@ def get_history(title, include_text=True, domain="en.wikipedia.org"):
             rating,
             texts[i],
         )
-
-        # Compile the list of changes
+        if raw_html:
+            change.raw_html = texts[i]  # set raw_html attribute for raw HTML content
         history.append(change)
 
     return history

--- a/src/wikipedia_histories/get_histories.py
+++ b/src/wikipedia_histories/get_histories.py
@@ -178,7 +178,7 @@ async def get_texts(revids, lang_code="en", raw_html=False):
     return texts
 
 
-def get_history(title, include_text=True, raw_html=False, domain="en.wikipedia.org"):
+def get_history(title, include_text=True, domain="en.wikipedia.org", raw_html=False):
     """
     Collects everything and returns a list of Change objects
 
@@ -242,10 +242,9 @@ def get_history(title, include_text=True, raw_html=False, domain="en.wikipedia.o
             users[i],
             comments[i],
             rating,
-            texts[i],
+            content=None if raw_html else texts[i],
+            raw_html=texts[i] if raw_html else None,
         )
-        if raw_html:
-            change.raw_html = texts[i]  # set raw_html attribute for raw HTML content
         history.append(change)
 
     return history

--- a/src/wikipedia_histories/revision.py
+++ b/src/wikipedia_histories/revision.py
@@ -8,7 +8,7 @@ class Revision:
     Class to track data about each change of a page
     """
 
-    def __init__(self, index, title, time, revid, kind, user, comment, rating, content):
+    def __init__(self, index, title, time, revid, kind, user, comment, rating, content, raw_html=None):
         """
         Create a change object
 
@@ -31,6 +31,7 @@ class Revision:
         self.comment = comment
         self.rating = rating
         self.content = content
+        self.raw_html = raw_html
 
     def __str__(self):
         return str(self.revid)

--- a/tests/cassettes/test_domain_change/test_get_text_raw_html.yaml
+++ b/tests/cassettes/test_domain_change/test_get_text_raw_html.yaml
@@ -1,0 +1,170 @@
+interactions:
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - wikipedia-histories/1.1 (https://github.com/ndrezn/wikipedia-histories)
+    method: GET
+    uri: https://zh-min-nan.wikipedia.org/w/api.php?action=parse&format=json&oldid=321061
+  response:
+    body:
+      string: '{"parse":{"title":"Phoe-thai","pageid":28695,"revid":321061,"text":{"*":"<div
+        class=\"mw-content-ltr mw-parser-output\" lang=\"nan\" dir=\"ltr\"><figure
+        class=\"mw-default-size\" typeof=\"mw:File/Thumb\"><a href=\"/wiki/t%C3%B3ng-%C3%A0n:Human_Embryo_-_Approximately_8_weeks_estimated_gestational_age.jpg\"
+        class=\"mw-file-description\"><img src=\"//upload.wikimedia.org/wikipedia/commons/thumb/0/0b/Human_Embryo_-_Approximately_8_weeks_estimated_gestational_age.jpg/250px-Human_Embryo_-_Approximately_8_weeks_estimated_gestational_age.jpg\"
+        decoding=\"async\" width=\"250\" height=\"167\" class=\"mw-file-element\"
+        srcset=\"//upload.wikimedia.org/wikipedia/commons/thumb/0/0b/Human_Embryo_-_Approximately_8_weeks_estimated_gestational_age.jpg/500px-Human_Embryo_-_Approximately_8_weeks_estimated_gestational_age.jpg
+        2x\" data-file-width=\"3872\" data-file-height=\"2592\" /></a><figcaption>J\u00een-l\u016bi
+        8 l\u00e9-p\u00e0i s\u00ee \u00ea phoe-thai.</figcaption></figure>\n<p><b>Phoe-thai</b>
+        (<a href=\"/wiki/Eng-g%C3%AD\" title=\"Eng-g\u00ed\">Eng-g\u00ed</a>: <i>embryo</i>)
+        s\u012b <a href=\"/wiki/Hoat-io%CC%8Dk\" class=\"mw-redirect\" title=\"Hoat-io\u030dk\">hoat-io\u030dk</a>
+        \u00ea ch\u00e1-k\u00ee kai-to\u0101\u207f, t\u00f9i <a href=\"/wiki/Nn%CC%84g\"
+        title=\"Nn\u0304g\">nn\u0304g</a> he\u030dk-chi\u00e1 <a href=\"/w/index.php?title=Siu-cheng-nn%CC%84g&amp;action=edit&amp;redlink=1\"
+        class=\"new\" title=\"Siu-cheng-nn\u0304g (i\u00e1u-bo\u0113 si\u00e1)\">siu-cheng-nn\u0304g</a>
+        k\u00e1i-s\u00ed hun-lia\u030dt li\u00e1u-\u0101u kh\u00e1i-s\u00ed, k\u00e0u
+        i ch\u00fa-i\u00e0u <a href=\"/wiki/Kh%C3%AC-koan\" title=\"Kh\u00ec-koan\">kh\u00ec-koan</a>
+        h\u00eang-s\u00eang.\n</p>\n<table class=\"metadata plainlinks stub\" role=\"presentation\"
+        style=\"background:transparent\"><tbody><tr class=\"noresize\"><td><span typeof=\"mw:File\"><a
+        href=\"/wiki/t%C3%B3ng-%C3%A0n:Wiki_letter_w.svg\" class=\"mw-file-description\"><img
+        alt=\"Stub icon\" src=\"//upload.wikimedia.org/wikipedia/commons/thumb/6/6c/Wiki_letter_w.svg/40px-Wiki_letter_w.svg.png\"
+        decoding=\"async\" width=\"30\" height=\"30\" class=\"mw-file-element\" srcset=\"//upload.wikimedia.org/wikipedia/commons/thumb/6/6c/Wiki_letter_w.svg/60px-Wiki_letter_w.svg.png
+        2x\" data-file-width=\"44\" data-file-height=\"44\" /></a></span></td><td><i>P\u00fan
+        b\u00fbn-chiu\u207f s\u012b chi\u030dt phi\u207f <a href=\"/wiki/Wikipedia:Ph%C3%AD\"
+        title=\"Wikipedia:Ph\u00ed\">ph\u00ed-\u00e1-ki\u00e1\u207f</a>. L\u00ed thang
+        t\u00e0u <a class=\"external text\" data-mw-original-href=\"//zh-min-nan.wikipedia.org/w/index.php?title=Phoe-thai&amp;action=edit\"
+        href=\"https://zh-min-nan.wikipedia.org/w/index.php?title=Phoe-thai&amp;action=edit\">khok-chhiong</a>
+        l\u00e2i pang-ch\u014d\u0358 Wikipedia.</i><style data-mw-deduplicate=\"TemplateStyles:r3215574\">.mw-parser-output
+        .hlist dl,.mw-parser-output .hlist ol,.mw-parser-output .hlist ul{margin:0;padding:0}.mw-parser-output
+        .hlist dd,.mw-parser-output .hlist dt,.mw-parser-output .hlist li{margin:0;display:inline}.mw-parser-output
+        .hlist.inline,.mw-parser-output .hlist.inline dl,.mw-parser-output .hlist.inline
+        ol,.mw-parser-output .hlist.inline ul,.mw-parser-output .hlist dl dl,.mw-parser-output
+        .hlist dl ol,.mw-parser-output .hlist dl ul,.mw-parser-output .hlist ol dl,.mw-parser-output
+        .hlist ol ol,.mw-parser-output .hlist ol ul,.mw-parser-output .hlist ul dl,.mw-parser-output
+        .hlist ul ol,.mw-parser-output .hlist ul ul{display:inline}.mw-parser-output
+        .hlist .mw-empty-li{display:none}.mw-parser-output .hlist dt::after{content:\":
+        \"}.mw-parser-output .hlist dd::after,.mw-parser-output .hlist li::after{content:\"
+        \u00b7 \";font-weight:bold}.mw-parser-output .hlist dd:last-child::after,.mw-parser-output
+        .hlist dt:last-child::after,.mw-parser-output .hlist li:last-child::after{content:none}.mw-parser-output
+        .hlist dd dd:first-child::before,.mw-parser-output .hlist dd dt:first-child::before,.mw-parser-output
+        .hlist dd li:first-child::before,.mw-parser-output .hlist dt dd:first-child::before,.mw-parser-output
+        .hlist dt dt:first-child::before,.mw-parser-output .hlist dt li:first-child::before,.mw-parser-output
+        .hlist li dd:first-child::before,.mw-parser-output .hlist li dt:first-child::before,.mw-parser-output
+        .hlist li li:first-child::before{content:\" (\";font-weight:normal}.mw-parser-output
+        .hlist dd dd:last-child::after,.mw-parser-output .hlist dd dt:last-child::after,.mw-parser-output
+        .hlist dd li:last-child::after,.mw-parser-output .hlist dt dd:last-child::after,.mw-parser-output
+        .hlist dt dt:last-child::after,.mw-parser-output .hlist dt li:last-child::after,.mw-parser-output
+        .hlist li dd:last-child::after,.mw-parser-output .hlist li dt:last-child::after,.mw-parser-output
+        .hlist li li:last-child::after{content:\")\";font-weight:normal}.mw-parser-output
+        .hlist ol{counter-reset:listitem}.mw-parser-output .hlist ol>li{counter-increment:listitem}.mw-parser-output
+        .hlist ol>li::before{content:\" \"counter(listitem)\"\\a0 \"}.mw-parser-output
+        .hlist dd ol>li:first-child::before,.mw-parser-output .hlist dt ol>li:first-child::before,.mw-parser-output
+        .hlist li ol>li:first-child::before{content:\" (\"counter(listitem)\"\\a0
+        \"}</style><style data-mw-deduplicate=\"TemplateStyles:r3255482\">.mw-parser-output
+        .navbar{display:inline;font-weight:normal}.mw-parser-output .navbar-collapse{float:left;text-align:left}.mw-parser-output
+        .navbar-boxtext{word-spacing:0}.mw-parser-output .navbar ul{display:inline-block;white-space:nowrap;line-height:inherit}.mw-parser-output
+        .navbar-brackets::before{margin-right:-0.125em;content:\"[ \"}.mw-parser-output
+        .navbar-brackets::after{margin-left:-0.125em;content:\" ]\"}.mw-parser-output
+        .navbar li{word-spacing:-0.125em}.mw-parser-output .navbar a>span,.mw-parser-output
+        .navbar a>abbr{text-decoration:inherit}.mw-parser-output .navbar-mini abbr{font-variant:small-caps;border-bottom:none;text-decoration:none;cursor:inherit}.mw-parser-output
+        .navbar-ct-full{font-size:110%;margin:0 8em}.mw-parser-output .navbar-ct-mini{font-size:110%;margin:0
+        5em}html.skin-theme-clientpref-night .mw-parser-output .navbar li a abbr{color:var(--color-base)!important}@media(prefers-color-scheme:dark){html.skin-theme-clientpref-os
+        .mw-parser-output .navbar li a abbr{color:var(--color-base)!important}}@media
+        print{.mw-parser-output .navbar{display:none!important}}</style><div class=\"navbar
+        plainlinks hlist navbar-mini\" style=\"position: absolute; right: 15px; display:
+        none;\"><ul><li class=\"nv-view\"><a href=\"/wiki/Pang-b%C3%B4%CD%98:Ph%C3%AD\"
+        title=\"Pang-b\u00f4\u0358:Ph\u00ed\"><abbr title=\"Hi\u00e1n-s\u012b chit-\u00ea
+        pang-b\u00f4\u0358\">Hi\u00e1n</abbr></a></li><li class=\"nv-talk\"><a href=\"/w/index.php?title=Pang-b%C3%B4%CD%98_th%C3%B3-l%C5%ABn:Ph%C3%AD&amp;action=edit&amp;redlink=1\"
+        class=\"new\" title=\"Pang-b\u00f4\u0358 th\u00f3-l\u016bn:Ph\u00ed (i\u00e1u-bo\u0113
+        si\u00e1)\"><abbr title=\"Th\u00f3-l\u016bn chit-\u00ea pang-b\u00f4\u0358\">L\u016bn</abbr></a></li><li
+        class=\"nv-edit\"><a href=\"/wiki/Tek-pia%CC%8Dt:%E7%B7%A8%E8%BC%AF%E9%A0%81%E9%9D%A2/Pang-b%C3%B4%CD%98:Ph%C3%AD\"
+        title=\"Tek-pia\u030dt:\u7de8\u8f2f\u9801\u9762/Pang-b\u00f4\u0358:Ph\u00ed\"><abbr
+        title=\"Pian-chip chit-\u00ea pang-b\u00f4\">Pian</abbr></a></li></ul></div></td></tr></tbody></table>\n<!--
+        \nNewPP limit report\nParsed by mw\u2010api\u2010ext.eqiad.main\u201066d79c8c8\u2010kll79\nCached
+        time: 20260719020849\nCache expiry: 2592000\nReduced expiry: false\nComplications:
+        [prevent\u2010selective\u2010update]\nCPU time usage: 0.049 seconds\nReal
+        time usage: 0.063 seconds\nPreprocessor visited node count: 31/1000000\nRevision
+        size: 396/2097152 bytes\nPost\u2010expand include size: 3009/2097152 bytes\nTemplate
+        argument size: 0/2097152 bytes\nHighest expansion depth: 4/100\nExpensive
+        parser function count: 0/500\nUnstrip recursion depth: 0/20\nUnstrip post\u2010expand
+        size: 3639/5000000 bytes\nLua time usage: 0.029/10.000 seconds\nLua memory
+        usage: 851527/52428800 bytes\nNumber of Wikibase entities loaded: 0/500\n-->\n<!--\nTransclusion
+        expansion time report (%,ms,calls,template)\n100.00%   43.750      1 Pang-b\u00f4\u0358:Stub\n100.00%   43.750      1
+        -total\n 96.24%   42.106      1 Pang-b\u00f4\u0358:Asbox\n-->\n\n<!-- Render
+        ID c7cfd8aa-8316-11f1-8c6a-99329baa4614 -->\n\n<!-- Saved in RevisionOutputCache
+        with key zh_min_nanwiki:rcache:321061:dateformat=default and timestamp 20260719020849
+        and revision id 321061.\n -->\n</div>"},"langlinks":[{"lang":"af","url":"https://af.wikipedia.org/wiki/Embrio","langname":"\u5357\u975e\u8377\u862d\u6587","autonym":"Afrikaans","*":"Embrio"},{"lang":"ar","url":"https://ar.wikipedia.org/wiki/%D8%AC%D9%86%D9%8A%D9%86","langname":"\u963f\u62c9\u4f2f\u6587","autonym":"\u0627\u0644\u0639\u0631\u0628\u064a\u0629","*":"\u062c\u0646\u064a\u0646"},{"lang":"arc","url":"https://arc.wikipedia.org/wiki/%DC%A5%DC%98%DC%A0%DC%90","langname":"\u963f\u62c9\u7c73\u6587","autonym":"\u0710\u072a\u0721\u071d\u0710","*":"\u0725\u0718\u0720\u0710"},{"lang":"arz","url":"https://arz.wikipedia.org/wiki/%D8%AC%D9%86%D9%8A%D9%86_%D8%A8%D8%AF%D8%B1%D9%89","langname":"\u57c3\u53ca\u963f\u62c9\u4f2f\u6587","autonym":"\u0645\u0635\u0631\u0649","*":"\u062c\u0646\u064a\u0646
+        \u0628\u062f\u0631\u0649"},{"lang":"ast","url":"https://ast.wikipedia.org/wiki/Embri%C3%B3n","langname":"\u963f\u65af\u5716\u91cc\u4e9e\u6587","autonym":"asturianu","*":"Embri\u00f3n"},{"lang":"az","url":"https://az.wikipedia.org/wiki/Embrion","langname":"\u4e9e\u585e\u62dc\u7136\u6587","autonym":"az\u0259rbaycanca","*":"Embrion"},{"lang":"be-x-old","url":"https://be-tarask.wikipedia.org/wiki/%D0%97%D0%B0%D1%80%D0%BE%D0%B4%D0%B0%D0%BA","langname":"Belarusian
+        (Tara\u0161kievica orthography)","autonym":"\u0431\u0435\u043b\u0430\u0440\u0443\u0441\u043a\u0430\u044f
+        (\u0442\u0430\u0440\u0430\u0448\u043a\u0435\u0432\u0456\u0446\u0430)","*":"\u0417\u0430\u0440\u043e\u0434\u0430\u043a"},{"lang":"be","url":"https://be.wikipedia.org/wiki/%D0%AD%D0%BC%D0%B1%D1%80%D1%8B%D1%91%D0%BD","langname":"\u767d\u4fc4\u7f85\u65af\u6587","autonym":"\u0431\u0435\u043b\u0430\u0440\u0443\u0441\u043a\u0430\u044f","*":"\u042d\u043c\u0431\u0440\u044b\u0451\u043d"},{"lang":"bg","url":"https://bg.wikipedia.org/wiki/%D0%95%D0%BC%D0%B1%D1%80%D0%B8%D0%BE%D0%BD","langname":"\u4fdd\u52a0\u5229\u4e9e\u6587","autonym":"\u0431\u044a\u043b\u0433\u0430\u0440\u0441\u043a\u0438","*":"\u0415\u043c\u0431\u0440\u0438\u043e\u043d"},{"lang":"bn","url":"https://bn.wikipedia.org/wiki/%E0%A6%AD%E0%A7%8D%E0%A6%B0%E0%A7%82%E0%A6%A3","langname":"\u5b5f\u52a0\u62c9\u6587","autonym":"\u09ac\u09be\u0982\u09b2\u09be","*":"\u09ad\u09cd\u09b0\u09c2\u09a3"},{"lang":"bs","url":"https://bs.wikipedia.org/wiki/Zametak","langname":"\u6ce2\u58eb\u5c3c\u4e9e\u6587","autonym":"bosanski","*":"Zametak"},{"lang":"ca","url":"https://ca.wikipedia.org/wiki/Embri%C3%B3","langname":"\u52a0\u6cf0\u862d\u6587","autonym":"catal\u00e0","*":"Embri\u00f3"},{"lang":"ceb","url":"https://ceb.wikipedia.org/wiki/Embryo","langname":"\u5bbf\u9727\u6587","autonym":"Cebuano","*":"Embryo"},{"lang":"ckb","url":"https://ckb.wikipedia.org/wiki/%D8%A6%D8%A7%D9%88%D9%84%DB%95%D9%85%DB%95","langname":"\u4e2d\u5eab\u5fb7\u6587","autonym":"\u06a9\u0648\u0631\u062f\u06cc","*":"\u0626\u0627\u0648\u0644\u06d5\u0645\u06d5"},{"lang":"cs","url":"https://cs.wikipedia.org/wiki/Embryo","langname":"\u6377\u514b\u6587","autonym":"\u010de\u0161tina","*":"Embryo"},{"lang":"cv","url":"https://cv.wikipedia.org/wiki/%D0%AD%D0%BC%D0%B1%D1%80%D0%B8%D0%BE%D0%BD","langname":"\u695a\u74e6\u4ec0\u6587","autonym":"\u0447\u04d1\u0432\u0430\u0448\u043b\u0430","*":"\u042d\u043c\u0431\u0440\u0438\u043e\u043d"},{"lang":"da","url":"https://da.wikipedia.org/wiki/Embryon","langname":"\u4e39\u9ea5\u6587","autonym":"dansk","*":"Embryon"},{"lang":"de","url":"https://de.wikipedia.org/wiki/Embryo","langname":"\u5fb7\u6587","autonym":"Deutsch","*":"Embryo"},{"lang":"el","url":"https://el.wikipedia.org/wiki/%CE%88%CE%BC%CE%B2%CF%81%CF%85%CE%BF","langname":"\u5e0c\u81d8\u6587","autonym":"\u0395\u03bb\u03bb\u03b7\u03bd\u03b9\u03ba\u03ac","*":"\u0388\u03bc\u03b2\u03c1\u03c5\u03bf"},{"lang":"en","url":"https://en.wikipedia.org/wiki/Embryo","langname":"\u82f1\u6587","autonym":"English","*":"Embryo"},{"lang":"eo","url":"https://eo.wikipedia.org/wiki/Embrio","langname":"\u4e16\u754c\u6587","autonym":"Esperanto","*":"Embrio"},{"lang":"es","url":"https://es.wikipedia.org/wiki/Embri%C3%B3n","langname":"\u897f\u73ed\u7259\u6587","autonym":"espa\u00f1ol","*":"Embri\u00f3n"},{"lang":"et","url":"https://et.wikipedia.org/wiki/Embr%C3%BCo","langname":"\u611b\u6c99\u5c3c\u4e9e\u6587","autonym":"eesti","*":"Embr\u00fco"},{"lang":"eu","url":"https://eu.wikipedia.org/wiki/Enbrioi","langname":"\u5df4\u65af\u514b\u6587","autonym":"euskara","*":"Enbrioi"},{"lang":"fa","url":"https://fa.wikipedia.org/wiki/%D8%B1%D9%88%DB%8C%D8%A7%D9%86","langname":"\u6ce2\u65af\u6587","autonym":"\u0641\u0627\u0631\u0633\u06cc","*":"\u0631\u0648\u06cc\u0627\u0646"},{"lang":"fi","url":"https://fi.wikipedia.org/wiki/Alkio","langname":"\u82ac\u862d\u6587","autonym":"suomi","*":"Alkio"},{"lang":"fr","url":"https://fr.wikipedia.org/wiki/Embryon","langname":"\u6cd5\u6587","autonym":"fran\u00e7ais","*":"Embryon"},{"lang":"fy","url":"https://fy.wikipedia.org/wiki/Embryo","langname":"\u897f\u5f17\u91cc\u897f\u4e9e\u6587","autonym":"Frysk","*":"Embryo"},{"lang":"ga","url":"https://ga.wikipedia.org/wiki/Suth","langname":"\u611b\u723e\u862d\u6587","autonym":"Gaeilge","*":"Suth"},{"lang":"gl","url":"https://gl.wikipedia.org/wiki/Embri%C3%B3n","langname":"\u52a0\u5229\u897f\u4e9e\u6587","autonym":"galego","*":"Embri\u00f3n"},{"lang":"gn","url":"https://gn.wikipedia.org/wiki/Mit%C3%A3%C3%B1epyr%C5%A9","langname":"\u74dc\u62c9\u5c3c\u6587","autonym":"Ava\u00f1e''\u1ebd","*":"Mit\u00e3\u00f1epyr\u0169"},{"lang":"hi","url":"https://hi.wikipedia.org/wiki/%E0%A4%AD%E0%A5%8D%E0%A4%B0%E0%A5%82%E0%A4%A3","langname":"\u5370\u5730\u6587","autonym":"\u0939\u093f\u0928\u094d\u0926\u0940","*":"\u092d\u094d\u0930\u0942\u0923"},{"lang":"hr","url":"https://hr.wikipedia.org/wiki/Zametak","langname":"\u514b\u7f85\u57c3\u897f\u4e9e\u6587","autonym":"hrvatski","*":"Zametak"},{"lang":"ht","url":"https://ht.wikipedia.org/wiki/Abriyon","langname":"\u6d77\u5730\u6587","autonym":"Krey\u00f2l
+        ayisyen","*":"Abriyon"},{"lang":"hu","url":"https://hu.wikipedia.org/wiki/Embri%C3%B3","langname":"\u5308\u7259\u5229\u6587","autonym":"magyar","*":"Embri\u00f3"},{"lang":"hy","url":"https://hy.wikipedia.org/wiki/%D5%8D%D5%A1%D5%B2%D5%B4","langname":"\u4e9e\u7f8e\u5c3c\u4e9e\u6587","autonym":"\u0570\u0561\u0575\u0565\u0580\u0565\u0576","*":"\u054d\u0561\u0572\u0574"},{"lang":"id","url":"https://id.wikipedia.org/wiki/Embrio","langname":"\u5370\u5c3c\u6587","autonym":"Bahasa
+        Indonesia","*":"Embrio"},{"lang":"ie","url":"https://ie.wikipedia.org/wiki/Embrion","langname":"\u570b\u969b\u6587\uff08E\uff09","autonym":"Interlingue","*":"Embrion"},{"lang":"inh","url":"https://inh.wikipedia.org/wiki/%D0%A5%D0%B8%D1%82%D3%80%D0%BE%D0%B0%D1%80%D0%B0","langname":"\u5370\u53e4\u4ec0\u6587","autonym":"\u0433\u04c0\u0430\u043b\u0433\u04c0\u0430\u0439","*":"\u0425\u0438\u0442\u04c0\u043e\u0430\u0440\u0430"},{"lang":"io","url":"https://io.wikipedia.org/wiki/Embriono","langname":"\u4f0a\u591a\u6587","autonym":"Ido","*":"Embriono"},{"lang":"is","url":"https://is.wikipedia.org/wiki/F%C3%B3sturv%C3%ADsir","langname":"\u51b0\u5cf6\u6587","autonym":"\u00edslenska","*":"F\u00f3sturv\u00edsir"},{"lang":"it","url":"https://it.wikipedia.org/wiki/Embrione","langname":"\u7fa9\u5927\u5229\u6587","autonym":"italiano","*":"Embrione"},{"lang":"ja","url":"https://ja.wikipedia.org/wiki/%E8%83%9A","langname":"\u65e5\u6587","autonym":"\u65e5\u672c\u8a9e","*":"\u80da"},{"lang":"jv","url":"https://jv.wikipedia.org/wiki/Embrio","langname":"\u722a\u54c7\u6587","autonym":"Jawa","*":"Embrio"},{"lang":"ka","url":"https://ka.wikipedia.org/wiki/%E1%83%A9%E1%83%90%E1%83%9C%E1%83%90%E1%83%A1%E1%83%90%E1%83%AE%E1%83%98","langname":"\u55ac\u6cbb\u4e9e\u6587","autonym":"\u10e5\u10d0\u10e0\u10d7\u10e3\u10da\u10d8","*":"\u10e9\u10d0\u10dc\u10d0\u10e1\u10d0\u10ee\u10d8"},{"lang":"kab","url":"https://kab.wikipedia.org/wiki/Amgun","langname":"\u5361\u6bd4\u723e\u6587","autonym":"Taqbaylit","*":"Amgun"},{"lang":"kk","url":"https://kk.wikipedia.org/wiki/%D0%AD%D0%BC%D0%B1%D1%80%D0%B8%D0%BE%D0%BD","langname":"\u54c8\u85a9\u514b\u6587","autonym":"\u049b\u0430\u0437\u0430\u049b\u0448\u0430","*":"\u042d\u043c\u0431\u0440\u0438\u043e\u043d"},{"lang":"kn","url":"https://kn.wikipedia.org/wiki/%E0%B2%AD%E0%B3%8D%E0%B2%B0%E0%B3%82%E0%B2%A3","langname":"\u574e\u90a3\u9054\u6587","autonym":"\u0c95\u0ca8\u0ccd\u0ca8\u0ca1","*":"\u0cad\u0ccd\u0cb0\u0cc2\u0ca3"},{"lang":"ko","url":"https://ko.wikipedia.org/wiki/%EB%B0%B0_(%EC%83%9D%EB%AC%BC%ED%95%99)","langname":"\u97d3\u6587","autonym":"\ud55c\uad6d\uc5b4","*":"\ubc30
+        (\uc0dd\ubb3c\ud559)"},{"lang":"ky","url":"https://ky.wikipedia.org/wiki/%D0%A2%D2%AF%D0%B9%D2%AF%D0%BB%D0%B4%D2%AF%D0%BA","langname":"\u5409\u723e\u5409\u65af\u6587","autonym":"\u043a\u044b\u0440\u0433\u044b\u0437\u0447\u0430","*":"\u0422\u04af\u0439\u04af\u043b\u0434\u04af\u043a"},{"lang":"la","url":"https://la.wikipedia.org/wiki/Embryo","langname":"\u62c9\u4e01\u6587","autonym":"Latina","*":"Embryo"},{"lang":"lb","url":"https://lb.wikipedia.org/wiki/Embryo","langname":"\u76e7\u68ee\u5821\u6587","autonym":"L\u00ebtzebuergesch","*":"Embryo"},{"lang":"lt","url":"https://lt.wikipedia.org/wiki/Gemalas","langname":"\u7acb\u9676\u5b9b\u6587","autonym":"lietuvi\u0173","*":"Gemalas"},{"lang":"lv","url":"https://lv.wikipedia.org/wiki/Embrijs","langname":"\u62c9\u812b\u7dad\u4e9e\u6587","autonym":"latvie\u0161u","*":"Embrijs"},{"lang":"mk","url":"https://mk.wikipedia.org/wiki/%D0%97%D0%B0%D1%80%D0%BE%D0%B4%D0%BE%D0%BA","langname":"\u99ac\u5176\u9813\u6587","autonym":"\u043c\u0430\u043a\u0435\u0434\u043e\u043d\u0441\u043a\u0438","*":"\u0417\u0430\u0440\u043e\u0434\u043e\u043a"},{"lang":"ml","url":"https://ml.wikipedia.org/wiki/%E0%B4%AD%E0%B5%8D%E0%B4%B0%E0%B5%82%E0%B4%A3%E0%B4%82","langname":"\u99ac\u4f86\u4e9e\u62c9\u59c6\u6587","autonym":"\u0d2e\u0d32\u0d2f\u0d3e\u0d33\u0d02","*":"\u0d2d\u0d4d\u0d30\u0d42\u0d23\u0d02"},{"lang":"mn","url":"https://mn.wikipedia.org/wiki/%D2%AE%D1%80_%D1%85%D3%A9%D0%B2%D1%80%D3%A9%D0%BB","langname":"\u8499\u53e4\u6587","autonym":"\u043c\u043e\u043d\u0433\u043e\u043b","*":"\u04ae\u0440
+        \u0445\u04e9\u0432\u0440\u04e9\u043b"},{"lang":"mr","url":"https://mr.wikipedia.org/wiki/%E0%A4%AD%E0%A5%8D%E0%A4%B0%E0%A5%82%E0%A4%A3","langname":"\u99ac\u62c9\u5730\u6587","autonym":"\u092e\u0930\u093e\u0920\u0940","*":"\u092d\u094d\u0930\u0942\u0923"},{"lang":"ms","url":"https://ms.wikipedia.org/wiki/Embrio","langname":"\u99ac\u4f86\u6587","autonym":"Bahasa
+        Melayu","*":"Embrio"},{"lang":"ne","url":"https://ne.wikipedia.org/wiki/%E0%A4%AD%E0%A5%8D%E0%A4%B0%E0%A5%82%E0%A4%A3","langname":"\u5c3c\u6cca\u723e\u6587","autonym":"\u0928\u0947\u092a\u093e\u0932\u0940","*":"\u092d\u094d\u0930\u0942\u0923"},{"lang":"nl","url":"https://nl.wikipedia.org/wiki/Embryo","langname":"\u8377\u862d\u6587","autonym":"Nederlands","*":"Embryo"},{"lang":"no","url":"https://no.wikipedia.org/wiki/Embryo","langname":"\u632a\u5a01\u6587","autonym":"norsk","*":"Embryo"},{"lang":"oc","url":"https://oc.wikipedia.org/wiki/Embrion","langname":"\u5967\u514b\u897f\u5766\u6587","autonym":"occitan","*":"Embrion"},{"lang":"om","url":"https://om.wikipedia.org/wiki/Miciree","langname":"\u5967\u7f85\u83ab\u6587","autonym":"Oromoo","*":"Miciree"},{"lang":"pa","url":"https://pa.wikipedia.org/wiki/%E0%A8%AD%E0%A8%B0%E0%A9%82%E0%A8%A3","langname":"\u65c1\u906e\u666e\u6587","autonym":"\u0a2a\u0a70\u0a1c\u0a3e\u0a2c\u0a40","*":"\u0a2d\u0a30\u0a42\u0a23"},{"lang":"pl","url":"https://pl.wikipedia.org/wiki/Zarodek","langname":"\u6ce2\u862d\u6587","autonym":"polski","*":"Zarodek"},{"lang":"pms","url":"https://pms.wikipedia.org/wiki/Embrion","langname":"\u76ae\u57c3\u8499\u7279\u6587","autonym":"Piemont\u00e8is","*":"Embrion"},{"lang":"ps","url":"https://ps.wikipedia.org/wiki/%D8%AC%D9%86%D9%8A%D9%86","langname":"\u666e\u4ec0\u5716\u6587","autonym":"\u067e\u069a\u062a\u0648","*":"\u062c\u0646\u064a\u0646"},{"lang":"pt","url":"https://pt.wikipedia.org/wiki/Embri%C3%A3o","langname":"\u8461\u8404\u7259\u6587","autonym":"portugu\u00eas","*":"Embri\u00e3o"},{"lang":"ro","url":"https://ro.wikipedia.org/wiki/Embrion","langname":"\u7f85\u99ac\u5c3c\u4e9e\u6587","autonym":"rom\u00e2n\u0103","*":"Embrion"},{"lang":"ru","url":"https://ru.wikipedia.org/wiki/%D0%AD%D0%BC%D0%B1%D1%80%D0%B8%D0%BE%D0%BD","langname":"\u4fc4\u6587","autonym":"\u0440\u0443\u0441\u0441\u043a\u0438\u0439","*":"\u042d\u043c\u0431\u0440\u0438\u043e\u043d"},{"lang":"sh","url":"https://sh.wikipedia.org/wiki/Zametak","langname":"\u585e\u723e\u7dad\u4e9e\u514b\u7f85\u57c3\u897f\u4e9e\u6587","autonym":"srpskohrvatski
+        / \u0441\u0440\u043f\u0441\u043a\u043e\u0445\u0440\u0432\u0430\u0442\u0441\u043a\u0438","*":"Zametak"},{"lang":"simple","url":"https://simple.wikipedia.org/wiki/Embryo","langname":"Simple
+        English","autonym":"Simple English","*":"Embryo"},{"lang":"sk","url":"https://sk.wikipedia.org/wiki/Embryo","langname":"\u65af\u6d1b\u4f10\u514b\u6587","autonym":"sloven\u010dina","*":"Embryo"},{"lang":"sl","url":"https://sl.wikipedia.org/wiki/Zarodek","langname":"\u65af\u6d1b\u7dad\u5c3c\u4e9e\u6587","autonym":"sloven\u0161\u010dina","*":"Zarodek"},{"lang":"sq","url":"https://sq.wikipedia.org/wiki/Embrioni","langname":"\u963f\u723e\u5df4\u5c3c\u4e9e\u6587","autonym":"shqip","*":"Embrioni"},{"lang":"sr","url":"https://sr.wikipedia.org/wiki/%D0%95%D0%BC%D0%B1%D1%80%D0%B8%D0%BE%D0%BD","langname":"\u585e\u723e\u7dad\u4e9e\u6587","autonym":"\u0441\u0440\u043f\u0441\u043a\u0438
+        / srpski","*":"\u0415\u043c\u0431\u0440\u0438\u043e\u043d"},{"lang":"su","url":"https://su.wikipedia.org/wiki/%C3%89mbrio","langname":"\u5dfd\u4ed6\u6587","autonym":"Sunda","*":"\u00c9mbrio"},{"lang":"sv","url":"https://sv.wikipedia.org/wiki/Embryo","langname":"\u745e\u5178\u6587","autonym":"svenska","*":"Embryo"},{"lang":"ta","url":"https://ta.wikipedia.org/wiki/%E0%AE%AE%E0%AF%81%E0%AE%B3%E0%AF%88%E0%AE%AF%E0%AE%AE%E0%AF%8D","langname":"\u5766\u7c73\u723e\u6587","autonym":"\u0ba4\u0bae\u0bbf\u0bb4\u0bcd","*":"\u0bae\u0bc1\u0bb3\u0bc8\u0baf\u0bae\u0bcd"},{"lang":"te","url":"https://te.wikipedia.org/wiki/%E0%B0%AA%E0%B0%BF%E0%B0%82%E0%B0%A1%E0%B0%82_(%E0%B0%8E%E0%B0%82%E0%B0%AC%E0%B1%8D%E0%B0%B0%E0%B0%AF%E0%B1%8B)","langname":"\u6cf0\u76e7\u56fa\u6587","autonym":"\u0c24\u0c46\u0c32\u0c41\u0c17\u0c41","*":"\u0c2a\u0c3f\u0c02\u0c21\u0c02
+        (\u0c0e\u0c02\u0c2c\u0c4d\u0c30\u0c2f\u0c4b)"},{"lang":"tg","url":"https://tg.wikipedia.org/wiki/%D2%B6%D0%B0%D0%BD%D0%B8%D0%BD","langname":"\u5854\u5409\u514b\u6587","autonym":"\u0442\u043e\u04b7\u0438\u043a\u04e3","*":"\u04b6\u0430\u043d\u0438\u043d"},{"lang":"th","url":"https://th.wikipedia.org/wiki/%E0%B9%80%E0%B8%AD%E0%B9%87%E0%B8%A1%E0%B8%9A%E0%B8%A3%E0%B8%B4%E0%B9%82%E0%B8%AD","langname":"\u6cf0\u6587","autonym":"\u0e44\u0e17\u0e22","*":"\u0e40\u0e2d\u0e47\u0e21\u0e1a\u0e23\u0e34\u0e42\u0e2d"},{"lang":"tl","url":"https://tl.wikipedia.org/wiki/Bilig","langname":"\u4ed6\u52a0\u797f\u6587","autonym":"Tagalog","*":"Bilig"},{"lang":"tr","url":"https://tr.wikipedia.org/wiki/Embriyo","langname":"\u571f\u8033\u5176\u6587","autonym":"T\u00fcrk\u00e7e","*":"Embriyo"},{"lang":"uk","url":"https://uk.wikipedia.org/wiki/%D0%95%D0%BC%D0%B1%D1%80%D1%96%D0%BE%D0%BD","langname":"\u70cf\u514b\u862d\u6587","autonym":"\u0443\u043a\u0440\u0430\u0457\u043d\u0441\u044c\u043a\u0430","*":"\u0415\u043c\u0431\u0440\u0456\u043e\u043d"},{"lang":"ur","url":"https://ur.wikipedia.org/wiki/%D8%AC%D9%86%DB%8C%D9%86","langname":"\u70cf\u90fd\u6587","autonym":"\u0627\u0631\u062f\u0648","*":"\u062c\u0646\u06cc\u0646"},{"lang":"uz","url":"https://uz.wikipedia.org/wiki/Embrion","langname":"\u70cf\u8332\u5225\u514b\u6587","autonym":"o\u02bbzbekcha
+        / \u045e\u0437\u0431\u0435\u043a\u0447\u0430","*":"Embrion"},{"lang":"vec","url":"https://vec.wikipedia.org/wiki/Enbrion","langname":"\u5a01\u5c3c\u65af\u6587","autonym":"v\u00e8neto","*":"Enbrion"},{"lang":"vi","url":"https://vi.wikipedia.org/wiki/Ph%C3%B4i","langname":"\u8d8a\u5357\u6587","autonym":"Ti\u1ebfng
+        Vi\u1ec7t","*":"Ph\u00f4i"},{"lang":"war","url":"https://war.wikipedia.org/wiki/Embryon_(biyolohiya)","langname":"\u74e6\u745e\u6587","autonym":"Winaray","*":"Embryon
+        (biyolohiya)"},{"lang":"wuu","url":"https://wuu.wikipedia.org/wiki/%E8%83%9A%E8%83%8E","langname":"\u5433\u8a9e","autonym":"\u5434\u8bed","*":"\u80da\u80ce"},{"lang":"zh-yue","url":"https://zh-yue.wikipedia.org/wiki/%E8%83%9A%E8%83%8E","langname":"\u7cb5\u8a9e","autonym":"\u7cb5\u8a9e","*":"\u80da\u80ce"},{"lang":"zh","url":"https://zh.wikipedia.org/wiki/%E8%83%9A%E8%83%8E","langname":"\u4e2d\u6587","autonym":"\u4e2d\u6587","*":"\u80da\u80ce"}],"categories":[{"sortkey":"","hidden":"","*":"Cho\u00e2n-p\u014d\u0358_ph\u00ed-\u00e1-ki\u00e1\u207f_b\u00fbn-chiu\u207f"},{"sortkey":"","hidden":"","*":"Ph\u00ed-\u00e1-ki\u00e1\u207f"},{"sortkey":"","*":"Seng-bu\u030dt-ha\u030dk"}],"links":[{"ns":10,"exists":"","*":"Pang-b\u00f4\u0358:Ph\u00ed"},{"ns":0,"exists":"","*":"Eng-g\u00ed"},{"ns":0,"exists":"","*":"Hoat-io\u030dk"},{"ns":0,"exists":"","*":"Kh\u00ec-koan"},{"ns":0,"exists":"","*":"Nn\u0304g"},{"ns":0,"*":"Siu-cheng-nn\u0304g"},{"ns":4,"exists":"","*":"Wikipedia:Ph\u00ed"},{"ns":11,"*":"Pang-b\u00f4\u0358
+        th\u00f3-l\u016bn:Ph\u00ed"}],"templates":[{"ns":10,"exists":"","*":"Pang-b\u00f4\u0358:Stub"},{"ns":10,"exists":"","*":"Pang-b\u00f4\u0358:Ph\u00ed"},{"ns":10,"exists":"","*":"Pang-b\u00f4\u0358:Asbox"},{"ns":10,"exists":"","*":"Pang-b\u00f4\u0358:Hlist/styles.css"},{"ns":828,"exists":"","*":"\u6a21\u7d44:Asbox"},{"ns":828,"exists":"","*":"\u6a21\u7d44:Buffer"},{"ns":828,"exists":"","*":"\u6a21\u7d44:Arguments"},{"ns":828,"exists":"","*":"\u6a21\u7d44:Navbar"},{"ns":828,"exists":"","*":"\u6a21\u7d44:Navbar/configuration"},{"ns":828,"exists":"","*":"\u6a21\u7d44:Navbar/styles.css"}],"images":["Human_Embryo_-_Approximately_8_weeks_estimated_gestational_age.jpg","Wiki_letter_w.svg"],"externallinks":[],"sections":[],"tocdata":null,"parsewarnings":[],"displaytitle":"<span
+        lang=\"nan\" dir=\"ltr\"><span class=\"mw-page-title-main\">Phoe-thai</span></span>","iwlinks":[],"properties":[{"name":"page_image_free","*":"Human_Embryo_-_Approximately_8_weeks_estimated_gestational_age.jpg"},{"name":"wikibase_item","*":"Q33196"}]}}'
+    headers:
+      Age:
+      - '0'
+      Cache-Control:
+      - private, must-revalidate, max-age=0
+      Content-Disposition:
+      - inline; filename=api-result.json
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 19 Jul 2026 02:14:04 GMT
+      Server:
+      - mw-api-ext.eqiad.main-66d79c8c8-sfqk5
+      Set-Cookie:
+      - WMF-Last-Access=19-Jul-2026;Path=/;HttpOnly;secure;Expires=Thu, 20 Aug 2026
+        00:00:00 GMT
+      - WMF-Last-Access-Global=19-Jul-2026;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Thu,
+        20 Aug 2026 00:00:00 GMT
+      - GeoIP=CA:QC:Qu__bec:46.86:-71.25:v4; Path=/; secure; Domain=.wikipedia.org
+      - NetworkProbeLimit=0.001;Path=/;Secure;SameSite=None;Max-Age=3600
+      - WMF-Uniq=wT8ZYG1N5GxNeGVUxGmrIQOiAAAAAFvdqFHZ7JemZRbvUtdd0hQt6K3_RE1l8cIl;Domain=.wikipedia.org;Path=/;HttpOnly;secure;SameSite=None;Expires=Mon,
+        19 Jul 2027 00:00:00 GMT
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding,X-Subdomain,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,User-Agent
+      content-length:
+      - '26471'
+      content-security-policy:
+      - default-src 'self'; script-src 'none'; object-src 'none'
+      nel:
+      - '{ "report_to": "wm_nel", "max_age": 604800, "failure_fraction": 0.05, "success_fraction":
+        0.0}'
+      report-to:
+      - '{ "group": "wm_nel", "max_age": 604800, "endpoints": [{ "url": "https://intake-logging.wikimedia.org/v1/events?stream=w3c.reportingapi.network_error&schema_uri=/w3c/reportingapi/network_error/1.0.0"
+        }] }'
+      server-timing:
+      - cache;desc="pass", host;desc="cp1112",co_id;desc="1306104344"
+      strict-transport-security:
+      - max-age=106384710; includeSubDomains; preload
+      x-analytics:
+      - ''
+      x-cache:
+      - cp1112 miss, cp1112 pass
+      x-cache-status:
+      - pass
+      x-client-ip:
+      - 107.167.253.208
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-request-id:
+      - 833f8565-e94d-45a3-af56-0207ef191d95
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_domain_change.py
+++ b/tests/test_domain_change.py
@@ -1,4 +1,5 @@
 import asyncio
+import re
 
 from src import wikipedia_histories
 
@@ -72,6 +73,13 @@ def test_invalid_language_code() -> None:
     lang = ""
     text = asyncio.run(wikipedia_histories.get_text(321061, lang_code=lang))
     assert text == -1
+
+
+def test_get_text_raw_html() -> None:
+    # use a known revision id for testing raw html
+    html_text = asyncio.run(wikipedia_histories.get_text(321061, lang_code="zh-min-nan", raw_html=True))
+    # Check that the returned text contains an HTML tag (e.g., <p>)
+    assert re.search(r"<\s*p", html_text, re.IGNORECASE) is not None
 
 
 def test_integration() -> None:

--- a/tests/test_domain_change.py
+++ b/tests/test_domain_change.py
@@ -1,5 +1,4 @@
 import asyncio
-import re
 
 import pytest
 
@@ -75,7 +74,7 @@ def test_invalid_language_code() -> None:
 @pytest.mark.vcr
 def test_get_text_raw_html() -> None:
     html_text = asyncio.run(wikipedia_histories.get_text(321061, lang_code="zh-min-nan", raw_html=True))
-    assert re.search(r"<\s*p", html_text, re.IGNORECASE) is not None
+    assert "<p" in html_text
 
 
 @pytest.mark.vcr

--- a/tests/test_domain_change.py
+++ b/tests/test_domain_change.py
@@ -1,4 +1,5 @@
 import asyncio
+import re
 
 import pytest
 
@@ -69,6 +70,12 @@ def test_invalid_language_code() -> None:
     lang = ""
     text = asyncio.run(wikipedia_histories.get_text(321061, lang_code=lang))
     assert text == -1
+
+
+@pytest.mark.vcr
+def test_get_text_raw_html() -> None:
+    html_text = asyncio.run(wikipedia_histories.get_text(321061, lang_code="zh-min-nan", raw_html=True))
+    assert re.search(r"<\s*p", html_text, re.IGNORECASE) is not None
 
 
 @pytest.mark.vcr


### PR DESCRIPTION
This pull request introduces a new feature to optionally retrieve raw HTML content from Wikipedia revisions, alongside the existing plain text option. It modifies several functions to support this feature and adds a new test case to ensure its correctness.

### Feature Enhancements:
Added a `raw_html` parameter to the `get_text`, `get_texts`, and `get_history` functions, enabling the retrieval of raw HTML content. Updated the logic to handle this parameter and return raw HTML when specified.

### Testing:
Added a new test case, `test_get_text_raw_html`, to verify that the `get_text` function correctly retrieves raw HTML content when the `raw_html` flag is set. The test checks for the presence of HTML tags in the returned content.