### PR TITLE
Add split output mode

### DIFF
--- a/src/wikipedia_histories/get_histories.py
+++ b/src/wikipedia_histories/get_histories.py
@@ -108,7 +108,7 @@ def get_ratings(talk):
     return ratings
 
 
-async def get_text(revid, attempts=0, lang_code="en", raw_html=False):
+async def get_text(revid, attempts=0, lang_code="en", raw_html=False, split=False):
     """
     Pull plain text or raw HTML representation of a revision from API.
 
@@ -117,6 +117,7 @@ async def get_text(revid, attempts=0, lang_code="en", raw_html=False):
         attempts: The number of attempts at retrieving the id so far
         lang_code: language code for the wikipedia domain
         raw_html: If True, return raw HTML content (unparsed) instead of plain text.
+        split: If True, return paragraphs as a list instead of a joined string.
     """
     try:
         # async implementation of requests get
@@ -132,7 +133,7 @@ async def get_text(revid, attempts=0, lang_code="en", raw_html=False):
         if attempts == 10:
             return -1
         # If there's a server error, just re-send the request until the server complies
-        return await get_text(revid, attempts=attempts + 1, lang_code=lang_code, raw_html=raw_html)
+        return await get_text(revid, attempts=attempts + 1, lang_code=lang_code, raw_html=raw_html, split=split)
     # Check if page was deleted (deleted pages have no text and are therefore un-parsable)
     try:
         raw_html_content = response["parse"]["text"]["*"]
@@ -146,18 +147,15 @@ async def get_text(revid, attempts=0, lang_code="en", raw_html=False):
 
     # Parse raw html from response
     document = html.document_fromstring(raw_html_content)
-    text = document.xpath("//p")
-    paragraphs = []
-    for paragraph in text:
-        paragraphs.append(paragraph.text_content())
+    paragraphs = [p.text_content() for p in document.xpath("//p")]
 
-    # Put everything together
-    cur = "".join(paragraphs)
+    if split:
+        return paragraphs
 
-    return cur
+    return "".join(paragraphs)
 
 
-async def get_texts(revids, lang_code="en", raw_html=False):
+async def get_texts(revids, lang_code="en", raw_html=False, split=False):
     """
     Get the text of articles given the list of revision ids
 
@@ -173,12 +171,12 @@ async def get_texts(revids, lang_code="en", raw_html=False):
     sema = 100
     for i in range(0, revids.__len__(), +sema):
         texts += await asyncio.gather(
-            *(get_text(revid, lang_code=lang_code, raw_html=raw_html) for revid in revids[i : (i + sema)])
+            *(get_text(revid, lang_code=lang_code, raw_html=raw_html, split=split) for revid in revids[i : (i + sema)])
         )
     return texts
 
 
-def get_history(title, include_text=True, domain="en.wikipedia.org", raw_html=False, start=None, end=None, limit=None):
+def get_history(title, include_text=True, domain="en.wikipedia.org", raw_html=False, split=False, start=None, end=None, limit=None):
     """
     Collects everything and returns a list of Change objects
 
@@ -227,7 +225,7 @@ def get_history(title, include_text=True, domain="en.wikipedia.org", raw_html=Fa
     # Get the text of the revisions. Performance is improved if this isn't done, but you lose the revisions
     if include_text:
         lang_code = extract_lang_code_from_domain(domain)
-        texts = asyncio.run(get_texts(revids, lang_code, raw_html=raw_html))
+        texts = asyncio.run(get_texts(revids, lang_code, raw_html=raw_html, split=split))
     else:
         texts = [""] * len(metadata)
 

--- a/tests/cassettes/test_domain_change/test_get_text_split.yaml
+++ b/tests/cassettes/test_domain_change/test_get_text_split.yaml
@@ -1,0 +1,141 @@
+interactions:
+- request:
+    body: null
+    headers:
+      User-Agent:
+      - wikipedia-histories/1.1 (https://github.com/ndrezn/wikipedia-histories)
+    method: GET
+    uri: https://en.wikipedia.org/w/api.php?action=parse&format=json&oldid=31820970&prop=text&disablelimitreport=1&disabletoc=1
+  response:
+    body:
+      string: '{"parse":{"title":"Andrei Broder","pageid":3458109,"revid":31820970,"text":{"*":"<div
+        class=\"mw-content-ltr mw-parser-output\" lang=\"en\" dir=\"ltr\"><p><b>Andrei
+        Broder</b> is a Research Fellow and Vice President of Emerging Search Technology
+        for <a href=\"/wiki/Yahoo\" title=\"Yahoo\">Yahoo</a>. He previously has worked
+        for <a href=\"/wiki/AltaVista\" title=\"AltaVista\">AltaVista</a> as the vice
+        president of research, and for <a href=\"/wiki/IBM_Research\" title=\"IBM
+        Research\">IBM Research</a> as a Distinguished Engineer &amp; CTO.\n</p><p>He
+        has done research into the <a href=\"/wiki/Internet\" title=\"Internet\">internet</a>,
+        and internet searching. He is credited with being one of the first people
+        to develop a <a href=\"/wiki/Captcha\" class=\"mw-redirect\" title=\"Captcha\">Captcha</a>,
+        while working for AltaVista.\n</p><p>He earned his PhD from <a href=\"/wiki/Stanford_University\"
+        title=\"Stanford University\">Stanford University</a> in <a href=\"/wiki/1985\"
+        title=\"1985\">1985</a>, where his advisor was <a href=\"/wiki/Donald_Knuth\"
+        title=\"Donald Knuth\">Donald Knuth</a>.\n</p>\n<style data-mw-deduplicate=\"TemplateStyles:r1364181290\">.mw-parser-output
+        .asbox{position:relative;overflow:hidden}.mw-parser-output .asbox table{background:transparent}.mw-parser-output
+        .asbox p{margin:0}.mw-parser-output .asbox p+p{margin-top:0.25em}.mw-parser-output
+        .asbox-body{font-style:italic}.mw-parser-output .asbox-note{font-size:smaller}.mw-parser-output
+        .asbox .navbar{position:absolute;top:-0.75em;right:1em;display:none}.mw-parser-output
+        :not(p):not(.asbox)+.mw-empty-elt+.asbox{margin-top:3em}</style><div role=\"note\"
+        class=\"metadata plainlinks asbox stub\"><table role=\"presentation\"><tbody><tr
+        class=\"noresize\"><td><span typeof=\"mw:File\"><a href=\"/wiki/File:Desktop_computer_clipart_-_Yellow_theme.svg\"
+        class=\"mw-file-description\"><img alt=\"Stub icon\" src=\"//upload.wikimedia.org/wikipedia/commons/thumb/d/d7/Desktop_computer_clipart_-_Yellow_theme.svg/40px-Desktop_computer_clipart_-_Yellow_theme.svg.png\"
+        decoding=\"async\" width=\"40\" height=\"29\" class=\"mw-file-element\" srcset=\"//upload.wikimedia.org/wikipedia/commons/thumb/d/d7/Desktop_computer_clipart_-_Yellow_theme.svg/120px-Desktop_computer_clipart_-_Yellow_theme.svg.png
+        2x\" data-file-width=\"281\" data-file-height=\"203\" /></a></span></td><td><p
+        class=\"asbox-body\">This biographical article relating to a computer specialist
+        is a <a href=\"/wiki/Wikipedia:Stub\" title=\"Wikipedia:Stub\">stub</a>. You
+        can help Wikipedia by <a class=\"external text\" data-mw-original-href=\"//en.wikipedia.org/w/index.php?title=Andrei_Broder&amp;action=edit\"
+        href=\"https://en.wikipedia.org/w/index.php?title=Andrei_Broder&amp;action=edit\">adding
+        missing information</a>.</p></td></tr></tbody></table><style data-mw-deduplicate=\"TemplateStyles:r1333133064\">.mw-parser-output
+        .hlist dl,.mw-parser-output .hlist ol,.mw-parser-output .hlist ul{margin:0;padding:0}.mw-parser-output
+        .hlist dd,.mw-parser-output .hlist dt,.mw-parser-output .hlist li{margin:0;display:inline}.mw-parser-output
+        .hlist.inline,.mw-parser-output .hlist.inline dl,.mw-parser-output .hlist.inline
+        ol,.mw-parser-output .hlist.inline ul,.mw-parser-output .hlist dl dl,.mw-parser-output
+        .hlist dl ol,.mw-parser-output .hlist dl ul,.mw-parser-output .hlist ol dl,.mw-parser-output
+        .hlist ol ol,.mw-parser-output .hlist ol ul,.mw-parser-output .hlist ul dl,.mw-parser-output
+        .hlist ul ol,.mw-parser-output .hlist ul ul{display:inline}.mw-parser-output
+        .hlist .mw-empty-li{display:none}.mw-parser-output .hlist dt::after{content:\":
+        \"}.mw-parser-output .hlist dd::after,.mw-parser-output .hlist li::after{content:\"\\a0
+        \u00b7 \";font-weight:bold}.mw-parser-output .hlist dd:last-child::after,.mw-parser-output
+        .hlist dt:last-child::after,.mw-parser-output .hlist li:last-child::after{content:none}.mw-parser-output
+        .hlist dd dd:first-child::before,.mw-parser-output .hlist dd dt:first-child::before,.mw-parser-output
+        .hlist dd li:first-child::before,.mw-parser-output .hlist dt dd:first-child::before,.mw-parser-output
+        .hlist dt dt:first-child::before,.mw-parser-output .hlist dt li:first-child::before,.mw-parser-output
+        .hlist li dd:first-child::before,.mw-parser-output .hlist li dt:first-child::before,.mw-parser-output
+        .hlist li li:first-child::before{content:\" (\";font-weight:normal}.mw-parser-output
+        .hlist dd dd:last-child::after,.mw-parser-output .hlist dd dt:last-child::after,.mw-parser-output
+        .hlist dd li:last-child::after,.mw-parser-output .hlist dt dd:last-child::after,.mw-parser-output
+        .hlist dt dt:last-child::after,.mw-parser-output .hlist dt li:last-child::after,.mw-parser-output
+        .hlist li dd:last-child::after,.mw-parser-output .hlist li dt:last-child::after,.mw-parser-output
+        .hlist li li:last-child::after{content:\")\";font-weight:normal}.mw-parser-output
+        .hlist ol{counter-reset:listitem}.mw-parser-output .hlist ol>li{counter-increment:listitem}.mw-parser-output
+        .hlist ol>li::before{content:\" \"counter(listitem)\"\\a0 \"}.mw-parser-output
+        .hlist dd ol>li:first-child::before,.mw-parser-output .hlist dt ol>li:first-child::before,.mw-parser-output
+        .hlist li ol>li:first-child::before{content:\" (\"counter(listitem)\"\\a0
+        \"}</style><style data-mw-deduplicate=\"TemplateStyles:r1239400231\">.mw-parser-output
+        .navbar{display:inline;font-size:88%;font-weight:normal}.mw-parser-output
+        .navbar-collapse{float:left;text-align:left}.mw-parser-output .navbar-boxtext{word-spacing:0}.mw-parser-output
+        .navbar ul{display:inline-block;white-space:nowrap;line-height:inherit}.mw-parser-output
+        .navbar-brackets::before{margin-right:-0.125em;content:\"[ \"}.mw-parser-output
+        .navbar-brackets::after{margin-left:-0.125em;content:\" ]\"}.mw-parser-output
+        .navbar li{word-spacing:-0.125em}.mw-parser-output .navbar a>span,.mw-parser-output
+        .navbar a>abbr{text-decoration:inherit}.mw-parser-output .navbar-mini abbr{font-variant:small-caps;border-bottom:none;text-decoration:none;cursor:inherit}.mw-parser-output
+        .navbar-ct-full{font-size:114%;margin:0 7em}.mw-parser-output .navbar-ct-mini{font-size:114%;margin:0
+        4em}html.skin-theme-clientpref-night .mw-parser-output .navbar li a abbr{color:var(--color-base)!important}@media(prefers-color-scheme:dark){html.skin-theme-clientpref-os
+        .mw-parser-output .navbar li a abbr{color:var(--color-base)!important}}@media
+        print{.mw-parser-output .navbar{display:none!important}}</style><div class=\"navbar
+        plainlinks hlist navbar-mini\"><ul><li class=\"nv-view\"><a href=\"/wiki/Template:Compu-bio-stub\"
+        title=\"Template:Compu-bio-stub\"><abbr title=\"View this template\">v</abbr></a></li><li
+        class=\"nv-talk\"><a href=\"/wiki/Template_talk:Compu-bio-stub\" title=\"Template
+        talk:Compu-bio-stub\"><abbr title=\"Discuss this template\">t</abbr></a></li><li
+        class=\"nv-edit\"><a href=\"/wiki/Special:EditPage/Template:Compu-bio-stub\"
+        title=\"Special:EditPage/Template:Compu-bio-stub\"><abbr title=\"Edit this
+        template\">e</abbr></a></li></ul></div></div></div>"}}}'
+    headers:
+      Age:
+      - '0'
+      Cache-Control:
+      - private, must-revalidate, max-age=0
+      Content-Disposition:
+      - inline; filename=api-result.json
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 19 Jul 2026 02:35:47 GMT
+      Server:
+      - mw-api-ext.eqiad.main-66d79c8c8-v6brj
+      Set-Cookie:
+      - WMF-Last-Access=19-Jul-2026;Path=/;HttpOnly;secure;Expires=Thu, 20 Aug 2026
+        00:00:00 GMT
+      - WMF-Last-Access-Global=19-Jul-2026;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Thu,
+        20 Aug 2026 00:00:00 GMT
+      - GeoIP=CA:QC:Qu__bec:46.86:-71.25:v4; Path=/; secure; Domain=.wikipedia.org
+      - NetworkProbeLimit=0.001;Path=/;Secure;SameSite=None;Max-Age=3600
+      - WMF-Uniq=Ehkc78Mcdd_VZZQyHrnNBwOiAAAAAFvdIfsDxheOPPu3U1mDh5-3hOn7zfQFCZVm;Domain=.wikipedia.org;Path=/;HttpOnly;secure;SameSite=None;Expires=Mon,
+        19 Jul 2027 00:00:00 GMT
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding,X-Subdomain,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization,User-Agent
+      content-length:
+      - '6997'
+      content-security-policy:
+      - default-src 'self'; script-src 'none'; object-src 'none'
+      nel:
+      - '{ "report_to": "wm_nel", "max_age": 604800, "failure_fraction": 0.05, "success_fraction":
+        0.0}'
+      report-to:
+      - '{ "group": "wm_nel", "max_age": 604800, "endpoints": [{ "url": "https://intake-logging.wikimedia.org/v1/events?stream=w3c.reportingapi.network_error&schema_uri=/w3c/reportingapi/network_error/1.0.0"
+        }] }'
+      server-timing:
+      - WMF-Uniq;desc="we-1-8-tempuser-post-edit=treatment;we-1-8-account-creation-no-desktop-benefits=treatment;",co_id;desc="1243685395"
+      strict-transport-security:
+      - max-age=106384710; includeSubDomains; preload
+      x-analytics:
+      - ''
+      x-cache:
+      - cp1112 miss, cp1112 pass
+      x-cache-status:
+      - pass
+      x-client-ip:
+      - 107.167.253.208
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-request-id:
+      - cf3965d0-bfa3-4761-b875-57ae282afe25
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_domain_change.py
+++ b/tests/test_domain_change.py
@@ -74,6 +74,13 @@ def test_invalid_language_code() -> None:
 
 
 @pytest.mark.vcr
+def test_get_text_split() -> None:
+    paragraphs = asyncio.run(wikipedia_histories.get_text(31820970, split=True))
+    assert isinstance(paragraphs, list)
+    assert any("Andrei Broder" in p for p in paragraphs)
+
+
+@pytest.mark.vcr
 def test_get_text_raw_html() -> None:
     html_text = asyncio.run(wikipedia_histories.get_text(321061, lang_code="zh-min-nan", raw_html=True))
     assert "<p" in html_text


### PR DESCRIPTION
## Summary

Adds a `split` parameter to `get_text`, `get_texts`, and `get_history`. When `True`, paragraph text is returned as a list instead of joined into a single string.

Closes #38.

## Usage

```python
paragraphs = asyncio.run(wikipedia_histories.get_text(revid, split=True))
# ["Andrei Broder is...", "He has done research...", ...]

history = wikipedia_histories.get_history("Paris", split=True)
# history[0].content is a list of paragraphs
```