### PR TITLE
Remove requirements files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-aiohttp>=3.8.0
-lxml>=4.9.1
-mwclient>=0.10.1
-mwparserfromhell>=0.6
-pandas>=1.2.3
-wikipedia-api>=0.5.4

--- a/requires-networks.txt
+++ b/requires-networks.txt
@@ -1,2 +1,0 @@
-networkx>=2.6
-python-igraph==0.9.1


### PR DESCRIPTION
Superseded by `pyproject.toml`. No references to either file exist in the codebase.