### PR TITLE
Bump version to 1.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wikipedia_histories"
-version = "1.2.0"
+version = "1.3.0"
 description = "A Python tool to pull the complete edit history of a Wikipedia page"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary

Bumps version from 1.2.0 to 1.3.0.

Changes since 1.2.0:
- Added `split` output mode to `get_text`, `get_texts`, and `get_history`
- Added `start`, `end`, and `limit` parameters to `get_history` for scoping large histories
- Reduced parse API payload (`prop=text`, `disablelimitreport`, `disabletoc`)
- Removed legacy `python-publish.yml` workflow
- Removed `requirements.txt` and `requires-networks.txt`